### PR TITLE
hotfix/remove-skipped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl.transitdata</groupId>
     <artifactId>transitdata-stop-estimates</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/src/main/java/fi/hsl/transitdata/stopestimates/models/PubtransData.java
+++ b/src/main/java/fi/hsl/transitdata/stopestimates/models/PubtransData.java
@@ -107,7 +107,16 @@ public class PubtransData {
         builder.setStopId(tripInfo.getStopId());
         builder.setStopSequence(common.getJourneyPatternSequenceNumber());
 
-        InternalMessages.StopEstimate.Status scheduledStatus = InternalMessages.StopEstimate.Status.SCHEDULED;
+
+        // TODO: 2019-05-23: Commenting code as temporary fix because OTP doesn't handle SKIPPED stop estimates well
+        // TODO: Uncomment and delete code below when OTP is fixed
+        // InternalMessages.StopEstimate.Status scheduledStatus = (common.getState() == 3L) ?
+        //    InternalMessages.StopEstimate.Status.SKIPPED :
+        //    InternalMessages.StopEstimate.Status.SCHEDULED;
+
+        InternalMessages.StopEstimate.Status scheduledStatus = (common.getState() == 3L) ?
+                InternalMessages.StopEstimate.Status.SCHEDULED :
+                InternalMessages.StopEstimate.Status.SCHEDULED;
 
         builder.setStatus(scheduledStatus);
 

--- a/src/main/java/fi/hsl/transitdata/stopestimates/models/PubtransData.java
+++ b/src/main/java/fi/hsl/transitdata/stopestimates/models/PubtransData.java
@@ -107,9 +107,7 @@ public class PubtransData {
         builder.setStopId(tripInfo.getStopId());
         builder.setStopSequence(common.getJourneyPatternSequenceNumber());
 
-        InternalMessages.StopEstimate.Status scheduledStatus = (common.getState() == 3L) ?
-                InternalMessages.StopEstimate.Status.SKIPPED :
-                InternalMessages.StopEstimate.Status.SCHEDULED;
+        InternalMessages.StopEstimate.Status scheduledStatus = InternalMessages.StopEstimate.Status.SCHEDULED;
 
         builder.setStatus(scheduledStatus);
 


### PR DESCRIPTION
 - Temporary hotfix for removing SKIPPED stop estimates by making them SCHEDULED